### PR TITLE
Adding inflight method to header

### DIFF
--- a/Streams.subproj/MPWPipe.h
+++ b/Streams.subproj/MPWPipe.h
@@ -15,5 +15,6 @@
 -(instancetype)initWithFilters:(NSArray *)filters;
 -(void)setErrorTarget:newErrorTarget;
 -(void)addFilter:(id <Streaming>)newFilter;
+-(int)inflight;
 
 @end


### PR DESCRIPTION
Fixes compiler error about not being able to find inflight method
