### PR TITLE
Undo delay stream changes that cause crashes

### DIFF
--- a/Streams.subproj/MPWDelayStream.m
+++ b/Streams.subproj/MPWDelayStream.m
@@ -27,10 +27,8 @@
     NSTimeInterval relativeDelay=self.relativeDelay;
     if ( relativeDelay > 0) {
         if ( self.synchronous) {
-            [anObject retain];
             [NSThread sleepForTimeInterval:relativeDelay];
-            FORWARD(anObject);
-            [anObject autorelease];
+            [self.target writeObject:anObject sender:sender];
         } else {
             [[self afterDelay:relativeDelay] forward:anObject];
         }


### PR DESCRIPTION
Partial rollback of 669264040af34069eceb4c98abad8ccacf4feeb3. Instead of using FORWARD() macro, call writeObject:sender: directly.

Now we no longer crash. Undo retain/autorelease attempt at fixing crashes since it didn't solve the issue.