### PR TITLE
Fix some memory leaks

### DIFF
--- a/Streams.subproj/MPWPipe.m
+++ b/Streams.subproj/MPWPipe.m
@@ -37,6 +37,12 @@
     return self;
 }
 
+- (void)dealloc
+{
+    [_filters release];
+    [super dealloc];
+}
+
 -(MPWStream *)processFilterSpec:filter
 {
     if ( [filter isKindOfClass:[NSString class]]) {

--- a/Streams.subproj/MPWPipe.m
+++ b/Streams.subproj/MPWPipe.m
@@ -55,12 +55,12 @@
             }
         } else if ( [(NSString*)filter hasPrefix:@"["] && [(NSString*)filter hasSuffix:@"]"]) {
             NSString *key=[filter substringWithRange:NSMakeRange(1, [filter length]-2)];
-            filter=[MPWBlockFilterStream streamWithBlock:[^(id o){ return [o objectForKey:key]; } copy]];
+            filter=[MPWBlockFilterStream streamWithBlock:[[^(id o){ return [o objectForKey:key]; } copy] autorelease]];
         } else if ( [(NSString*)filter hasPrefix:@"%"]) {
             NSString *formatString=[filter substringWithRange:NSMakeRange(1, [filter length]-1)];
-            filter=[MPWBlockFilterStream streamWithBlock:[^(NSString *s){
+            filter=[MPWBlockFilterStream streamWithBlock:[[^(NSString *s){
                 return [NSString stringWithFormat:formatString,s];
-                        } copy]];
+                        } copy] autorelease]];
             [filter setTarget:nil];
         } else if ( [(NSString*)filter hasPrefix:@"!"]) {
             NSString *command=[filter substringWithRange:NSMakeRange(1, [filter length]-1)];
@@ -68,14 +68,17 @@
             [filter setTarget:nil];
         } else {
             NSString *key=[filter copy];
-            filter=[MPWBlockFilterStream streamWithBlock:[^(id o){ return [o valueForKey:key]; } copy]];
+            filter=[MPWBlockFilterStream streamWithBlock:[[^(id o){ return [o valueForKey:key]; } copy] autorelease]];
         }
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundeclared-selector"
     } else if ( [filter respondsToSelector:@selector(value:)] ) {
         filter=[MPWBlockFilterStream streamWithBlock:filter];
     } else if ( [filter respondsToSelector:@selector(setTarget:)] &&
                 [filter respondsToSelector:@selector(setAction:)] &&
                 [filter respondsToSelector:@selector(objectValue)] ) {
-        filter=[[MPWActionStreamAdapter alloc] initWithUIControl:filter target:nil];
+#pragma clang diagnostic pop
+        filter=[[[MPWActionStreamAdapter alloc] initWithUIControl:filter target:nil] autorelease];
     } else if ( [filter respondsToSelector:@selector(streamWithTarget:)] ) {
         filter=[(Class)filter streamWithTarget:nil];
     } else if ( [filter isKindOfClass:[NSArray class]]) {

--- a/Streams.subproj/MPWPipe.m
+++ b/Streams.subproj/MPWPipe.m
@@ -255,7 +255,7 @@ typedef id (^ZeroArgBlock)(void);
       [MPWMessageFilterStream streamWithSelector:@selector(uppercaseString)],
       [MPWBlockFilterStream streamWithBlock:^(NSString *s){ return [s stringByAppendingString:@" World!"]; }],
       ];
-    MPWPipe *pipe=[[self alloc] initWithFilters:filters];
+    MPWPipe *pipe=[[[self alloc] initWithFilters:filters] autorelease];
     [pipe writeObject:@"Hello"];
     IDEXPECT([[pipe target] firstObject], @"HELLO World!", @"hello world, processed");
 }
@@ -271,7 +271,7 @@ typedef id (^ZeroArgBlock)(void);
     @[
         first,third
       ];
-    MPWPipe *pipe=[[self alloc] initWithFilters:filters];
+    MPWPipe *pipe=[[[self alloc] initWithFilters:filters] autorelease];
     [pipe writeObject:@"Hello"];
     IDEXPECT([[pipe target] firstObject], @"HELLO World! Moon!", @"hello world, processed");
 }
@@ -280,7 +280,7 @@ typedef id (^ZeroArgBlock)(void);
 +(void)testCanUseStringsToSpecifyMessageFilter
 {
     NSArray *filters = @[ @"-uppercaseString"];
-    MPWPipe *pipe=[[self alloc] initWithFilters:filters];
+    MPWPipe *pipe=[[[self alloc] initWithFilters:filters] autorelease];
     [pipe writeObject:@"Hello"];
     IDEXPECT([[pipe target] firstObject], @"HELLO", @"hello, processed");
 }
@@ -288,7 +288,7 @@ typedef id (^ZeroArgBlock)(void);
 +(void)testCanUseStringsToSpecifyValueForKey
 {
     NSArray *filters = @[ @"uppercaseString"];
-    MPWPipe *pipe=[[self alloc] initWithFilters:filters];
+    MPWPipe *pipe=[[[self alloc] initWithFilters:filters] autorelease];
     [pipe writeObject:@"Hello"];
     IDEXPECT([[pipe target] firstObject], @"HELLO", @"hello, processed");
 }
@@ -296,7 +296,7 @@ typedef id (^ZeroArgBlock)(void);
 +(void)testCanUseStringsToSpecifyObjectForKey
 {
     NSArray *filters = @[ @"[key1]"];
-    MPWPipe *pipe=[[self alloc] initWithFilters:filters];
+    MPWPipe *pipe=[[[self alloc] initWithFilters:filters] autorelease];
     [pipe writeObject:@{ @"key1": @"Hello", @"key2": @"World"}];
     IDEXPECT([[pipe target] firstObject], @"Hello", @"hello, extracted");
 }
@@ -307,7 +307,7 @@ typedef id (^ZeroArgBlock)(void);
     @[
       ^(NSString *s){ return [s stringByAppendingString:@" World!"]; },
        ];
-    MPWPipe *pipe=[[self alloc] initWithFilters:filters];
+    MPWPipe *pipe=[[[self alloc] initWithFilters:filters] autorelease];
     [pipe writeObject:@"Hello"];
     IDEXPECT([[pipe target] firstObject], @"Hello World!", @"Hello world, processed");
 }

--- a/Streams.subproj/MPWPipe.m
+++ b/Streams.subproj/MPWPipe.m
@@ -223,7 +223,10 @@ typedef id (^ZeroArgBlock)(void);
     if  ( !initialized) {
         Class blockClass=NSClassFromString(@"NSBlock");
         IMP theImp=imp_implementationWithBlock( ^(id blockSelf, id argument){ ((OneArgBlock)blockSelf)(argument); } );
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundeclared-selector"
         class_addMethod(blockClass, @selector(value:), theImp, "@@:@");
+#pragma clang diagnostic pop
         initialized=YES;
     }
 }

--- a/Streams.subproj/MPWURLFetchStream.m
+++ b/Streams.subproj/MPWURLFetchStream.m
@@ -117,7 +117,10 @@ static NSURLSession *_defaultURLSession=nil;
 
 -(SEL)streamWriterMessage
 {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundeclared-selector"
     return @selector(writeOnURLFetchStream:);
+#pragma clang diagnostic pop
 }
 
 -(void)writeString:(NSString*)aString
@@ -339,6 +342,9 @@ static NSURLSession *_defaultURLSession=nil;
 //    NSLog(@"deallocating MPWURLFetchStream %p",self);
     [_inflight release];
     [_theHeaderDict release];
+    [_defaultMethod release];
+    [(NSObject *)_errorTarget release];
+    [_baseURL release];
     [super dealloc];
 }
 

--- a/Streams.subproj/MPWURLRequest.m
+++ b/Streams.subproj/MPWURLRequest.m
@@ -25,14 +25,14 @@
 {
     NSMutableURLRequest *r=[self.request mutableCopy];
     r.allHTTPHeaderFields=headerDict;
-    self.request=r;
+    self.request=[r autorelease];
 }
 
 -(void)setBodyData:(NSData *)bodyData
 {
     NSMutableURLRequest *r=[self.request mutableCopy];
     r.HTTPBody=bodyData;
-    self.request=r;
+    self.request=[r autorelease];
 }
 
 -(id)processed
@@ -53,6 +53,7 @@
     [_request release];
     [_response release];
     [_error release];
+    [_task release];
     
     [super dealloc];
 }


### PR DESCRIPTION
This is a screenshot that I took after running the mac app for 1 minute (just running it without touching anything):

![before](https://user-images.githubusercontent.com/1119053/31607778-94d51cdc-b265-11e7-96f2-ac25470af863.png)

I didn't know exactly where to start from but since MPWFoundation is a non-ARC project I thought to start from it and look for possible missing retain/release/autorelease stuff.
This is a portion of what the static analyser reports on MPWFoundationFramework:

![screen shot 2017-10-16 at 11 30 49](https://user-images.githubusercontent.com/1119053/31607881-13a2ba24-b266-11e7-91b3-934e5fdeaf7d.png)

What I presumably fixed in this PR seems to have improved the leaks on MPW a little, however there are still a lot of other leaks where I couldn't exactly identify the source yet.
This is a screenshot took after running the mac app for 1 minute with the patched version of MPW:

![screen shot 2017-10-16 at 11 47 08](https://user-images.githubusercontent.com/1119053/31608371-101b231c-b268-11e7-95ae-7ff8df24a5c8.png)

The leaks on MPW looks lower even though some are still there (but keeping the app running and using it for more than 10 minute did not increase the number of leaks).
My assumption is that a retain cycle might still occur around all the `MPWStream` subclasses because of how `target` is defined: 
`idAccessor( target, _setTarget )`
where its setter is then expanded as:
```
#define ASSIGN_ID(var,value)\
    {\
        id tempValue=(value);\
	if ( tempValue!=var) {  \
        if ( tempValue!=(id)self ) \
            [tempValue retain]; \
		if ( var && var!=(id)self) \
			[var release]; \
		var = tempValue; \
	} \
    }
```

`MPWStream` already deallocates the `target` properly, but what I'm thinking is that there might be a retain cycle between all the streams involved, and that might happen because none of them is using some sort of 'weak' reference to break the loop ('weak' did not exist in non-ARC but you have got the idea).
The reason why I'm thinking about a retain cycle around `target` is because the memory graph show me this:

![screen shot 2017-10-16 at 12 04 48](https://user-images.githubusercontent.com/1119053/31609657-fbf5f5ce-b26c-11e7-8cd1-81306908c723.png)

These are just my assumptions so far based on some observations, but of course they might be false assumptions due to my little knowledge on the MPW architecture.
Please also notice that this PR doesn't fix all the possible memory leaks reported by the static analyser, just part of them.